### PR TITLE
Removing quotes when regex and better handling exceptions

### DIFF
--- a/bin/check-influxdb-metrics.rb
+++ b/bin/check-influxdb-metrics.rb
@@ -129,12 +129,13 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
 
   def encode_parameters(parameters)
     encodedparams = Addressable::URI.escape(parameters)
-    puts encodedparams
+
     if $usingRegex
       encode_for_regex = encodedparams.gsub! '+', '%2B'
     else
       encode_for_regex = encodedparams
     end
+
     "#{config[:db]}&q=" + encode_for_regex
   end
 
@@ -151,6 +152,8 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
   def today_value
     second_query = today_query_encoded
     response_to_compare = request(second_query)
+    puts "TODAY!!"
+    puts response_to_compare
     read_metrics(response_to_compare)
   end
 
@@ -158,6 +161,8 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
     query = yesterday_query_encoded
     puts query
     response = request(query)
+    puts "YESTERDAY!!"
+    puts response
     read_metrics(response)
   end
 
@@ -169,7 +174,7 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
     else
       series = metrics[0]['series']
       values = series[0]['values'][0][1]
-
+      
       if values.nil?
         values = 0
       end

--- a/bin/check-influxdb-metrics.rb
+++ b/bin/check-influxdb-metrics.rb
@@ -222,7 +222,7 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
   end
 
   def display_metrics
-    puts 'Today metrics: '
+    puts 'Today metrics analysis: '
     @today_metrics.each do |key, value|
       puts 'For: ' + key + ' : ' + value.to_s
     end
@@ -298,10 +298,8 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
   def difference_in_metrics
     today = today_value
     yesterday = yesterday_value
-    if today.nil? && @is_using_regex == false
-      puts 'No results coming from InfluxDB for Today. Please check your query or try again'
-    elsif yesterday.nil? && @is_using_regex == false
-      puts 'No results coming from InfluxDB for Yesterday. Please check your query or try again'
+    if today.nil? && yesterday.nil?
+      puts 'No results coming from InfluxDB either for Today nor Yesterday. Please check your query or try again'
     else
       calculate_difference_and_display_result(today, yesterday)
     end


### PR DESCRIPTION
In this PR I aim to do a few things:

1. Allow the usage of regex expressions that we can identify as "/^[your_regex]$". I'll strongly recommend to use this only for exceptions, and always aim for zero-exceptions, or it wouldn't be accurate. At the moment it will fire when the number of exception today is bigger than the number of exceptions yesterday.
Also, if you have the same number of metrics found (let's say, exceptions) it will compare just the first one. I'll not rely on this tool (yet) for a deep analysis of differences in exceptions.
2. Improve feedback when returning null from InfluxDB (usually because the query is pointing to a metric that doesn't exists).

After the PR is completed documentation will be added about this changes.