### PR TITLE
Triangulation

### DIFF
--- a/bin/check-influxdb-metrics.rb
+++ b/bin/check-influxdb-metrics.rb
@@ -201,6 +201,7 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
               @today_triangulated_metrics = store_metrics(series)
               read_value_from_series(series)
             end
+    puts value
     value
   end
 
@@ -209,7 +210,7 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
     @yesterday_triangulated_metric_count = validate_metrics_and_count(yesterday_triangulated_info)
     value = if @yesterday_triangulated_metric_count > 0
               series = read_series_from_metrics(yesterday_triangulated_info)
-              @today_triangulated_metrics = store_metrics(series)
+              @yesterday_triangulated_metrics = store_metrics(series)
               read_value_from_series(series)
             end
     value

--- a/bin/check-influxdb-metrics.rb
+++ b/bin/check-influxdb-metrics.rb
@@ -96,7 +96,7 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
   option :distance,
          long: '--distance=VALUE',
          description: 'Set the distance threshold to alert in case of triangulation',
-         default: 10
+         default: 2
 
   BASE_QUERY = 'SELECT sum("value") from '.freeze
   TODAY_START_PERIOD = 10
@@ -270,7 +270,7 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
     elsif @today_metric_count == @yesterday_metric_count
       compare_each_metric_in_regex
     else
-      ok 'regex seems ok! Less metrics found yesterday (' + @yesterday_metric_count.to_s + ') vs (' + @today_metric_count.to_s + ') found today.'
+      ok 'regex seems ok! Today metrics dropped. Yesterday (' + @yesterday_metric_count.to_s + ') vs (' + @today_metric_count.to_s + ') found today.'
     end
   end
 


### PR DESCRIPTION
This PR increases the default period from 10 minutes to 25 minutes, and also enables the ability to evaluate the percentage of difference for metric A vs percentage of difference for metric B, and compare the **distance** in their percentages. 

Let's assume that metric A and metric B are related due to some business logic, if for example, for every 5 metrics A recorded we will get 1 metric B, their percentage of difference comparing to yesterday's weather will be the same. So the distance should be close. If there is a problem in any of the systems involved, one of the two will be far away from the other, and we'll get an exception.

This will help to diagnose weird behaviours.