### PR TITLE
Using absolute time instead of relative time

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,4 +35,8 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs, :test]
+
+task :test do
+  ruby 'tests/check-influxdb-metrics-tests.rb'
+end

--- a/bin/check-influxdb-metrics.rb
+++ b/bin/check-influxdb-metrics.rb
@@ -164,7 +164,6 @@ class CheckInfluxDbMetrics < Sensu::Plugin::Check::CLI
 
   def query_encoded_for_a_period(metric, start_period, end_period, istriangulated)
     query = query_for_a_period_timespan(metric, start_period, end_period, istriangulated)
-    puts query
     encode_parameters(query)
   end
 

--- a/bin/time-management.rb
+++ b/bin/time-management.rb
@@ -1,0 +1,25 @@
+class TimeManagement
+  TODAY_START_PERIOD = 5
+  YESTERDAY_START_PERIOD = 1445 # starts counting 1445 minutes before now() [ yesterday - 5 minutes] to match with today_query_for_a_period start_period
+
+  def today_start_period
+    TODAY_START_PERIOD
+  end
+
+  def yesterday_start_period
+    YESTERDAY_START_PERIOD
+  end
+
+  def period_seconds(a_given_day_period)
+    a_given_day_period * 60
+  end
+
+  def period_epoch(time, a_given_period)
+    period = time - period_seconds(a_given_period)
+    epoch_time(period)
+  end
+
+  def epoch_time(time)
+    time.to_i.to_s
+  end
+end

--- a/tests/check-influxdb-metrics-tests.rb
+++ b/tests/check-influxdb-metrics-tests.rb
@@ -1,6 +1,27 @@
 require 'test/unit'
-class CheckInfluxDbMetricsTests < Test::Unit::TestCase
-  def test_simple
-    assert_equal('a', CheckInfluxDbMetrics.encodeParameters('a'))
+require_relative '../bin/time-management'
+
+class TimePeriodTests < Test::Unit::TestCase
+  def test_today_start_period
+    assert_equal(5, TimeManagement.new.today_start_period)
+  end
+
+  def test_yesterday_start_period
+    assert_equal(1445, TimeManagement.new.yesterday_start_period)
+  end
+
+  def test_start_period_seconds
+    a_given_period = 5
+    assert_equal(5 * 60, TimeManagement.new.period_seconds(a_given_period))
+  end
+
+  def test_epoch_period
+    now = Time.now # current time
+    time_manager = TimeManagement.new # this is the time that you'll substract from now, to build your period
+    today_expected_epoch = time_manager.period_epoch(now, time_manager.today_start_period)
+
+    period = now - time_manager.period_seconds(time_manager.today_start_period)
+    expected_result_in_epoch = period.to_i.to_s
+    assert_equal(expected_result_in_epoch, today_expected_epoch)
   end
 end


### PR DESCRIPTION
`SELECT sum("value") from  "metric" WHERE time > 1485874960s AND time < 1485875560s`
turns out to be way more accurate:
`SELECT sum("value") from  "metric" WHERE time > now() - 1475m AND time < now() - 1445m`